### PR TITLE
Add missing return

### DIFF
--- a/code/commands/browser-commands.cpp
+++ b/code/commands/browser-commands.cpp
@@ -515,6 +515,7 @@ bool Gobby::BrowserCommands::create_chat_document(InfBrowser* browser)
 		iter->second->set_pending_chat(proxy);
 		return true;
 	}
+	Return false;
 }
 
 void Gobby::BrowserCommands::on_connect(const Glib::ustring& hostname)


### PR DESCRIPTION
Without this return false statement, rpmlint complains while building the package:

[  384s] I: Program returns random data in a function
[  384s] E: gobby no-return-in-nonvoid-function browser-commands.cpp:518
