### PR TITLE
Fix running on GTK 3.10

### DIFF
--- a/code/resources/ui/toolbar.ui
+++ b/code/resources/ui/toolbar.ui
@@ -3,7 +3,7 @@
   <object class="GtkToolbar" id="toolbar">
     <property name="can_focus">False</property>
     <child>
-      <object class="GtkToolButton">
+      <object class="GtkToolButton" id="toolbutton1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="action_name">win.new</property>
@@ -17,7 +17,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkToolButton">
+      <object class="GtkToolButton" id="toolbutton2">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="action_name">win.open</property>
@@ -31,7 +31,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkToolButton">
+      <object class="GtkToolButton" id="toolbutton3">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="action_name">win.save</property>
@@ -45,7 +45,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSeparatorToolItem">
+      <object class="GtkSeparatorToolItem" id="separator1">
         <property name="visible">True</property>
       </object>
       <packing>
@@ -53,7 +53,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkToolButton">
+      <object class="GtkToolButton" id="toolbutton4">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="action_name">win.undo</property>
@@ -67,7 +67,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkToolButton">
+      <object class="GtkToolButton" id="toolbutton5">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="action_name">win.redo</property>
@@ -81,7 +81,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSeparatorToolItem">
+      <object class="GtkSeparatorToolItem" id="separator2">
         <property name="visible">True</property>
       </object>
       <packing>
@@ -89,7 +89,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkToolButton">
+      <object class="GtkToolButton" id="toolbutton6">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="action_name">win.cut</property>
@@ -103,7 +103,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkToolButton">
+      <object class="GtkToolButton" id="toolbutton7">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="action_name">win.copy</property>
@@ -117,7 +117,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkToolButton">
+      <object class="GtkToolButton" id="toolbutton8">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="action_name">win.paste</property>
@@ -131,7 +131,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkSeparatorToolItem">
+      <object class="GtkSeparatorToolItem" id="separator3">
         <property name="visible">True</property>
       </object>
       <packing>
@@ -139,7 +139,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkToolButton">
+      <object class="GtkToolButton" id="toolbutton9">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="action_name">win.find</property>
@@ -153,7 +153,7 @@
       </packing>
     </child>
     <child>
-      <object class="GtkToolButton">
+      <object class="GtkToolButton" id="toolbutton10">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="action_name">win.find-replace</property>


### PR DESCRIPTION
The file resources/ui/toolbar.ui lacks an id attribute for most object
elements. Prior to GTK 3.11.2 they were required and so Gobby fails to
start.

https://bugzilla.gnome.org/show_bug.cgi?id=712553
http://ftp.gnome.org/pub/gnome/sources/gtk+/3.11/gtk+-3.11.2.news