### PR TITLE
Include only gtksourceview/gtksource.h

### DIFF
--- a/code/core/folder.hpp
+++ b/code/core/folder.hpp
@@ -25,7 +25,7 @@
 #include <gtkmm/notebook.h>
 #include <sigc++/signal.h>
 
-#include <gtksourceview/gtksourcelanguagemanager.h>
+#include <gtksourceview/gtksource.h>
 
 namespace Gobby
 {

--- a/code/core/menumanager.cpp
+++ b/code/core/menumanager.cpp
@@ -18,7 +18,7 @@
 
 #include <gtkmm/builder.h>
 
-#include <gtksourceview/gtksourcelanguage.h>
+#include <gtksourceview/gtksource.h>
 
 namespace
 {

--- a/code/core/menumanager.hpp
+++ b/code/core/menumanager.hpp
@@ -20,7 +20,7 @@
 #include <giomm/menumodel.h>
 #include <giomm/menu.h>
 
-#include <gtksourceview/gtksourcelanguagemanager.h>
+#include <gtksourceview/gtksource.h>
 
 namespace Gobby
 {

--- a/code/core/noteplugin.cpp
+++ b/code/core/noteplugin.cpp
@@ -28,7 +28,7 @@
 #include <libinfinity/common/inf-session.h>
 #include <libinfinity/common/inf-io.h>
 
-#include <gtksourceview/gtksourcebuffer.h>
+#include <gtksourceview/gtksource.h>
 
 namespace
 {

--- a/code/core/preferences.hpp
+++ b/code/core/preferences.hpp
@@ -25,8 +25,7 @@
 #include <gtkmm/toolbar.h>
 #include <giomm/settings.h>
 
-#include <gtksourceview/gtksourceview.h>
-#include <gtksourceview/gtksourcestyleschememanager.h>
+#include <gtksourceview/gtksource.h>
 
 #include <libinfinity/common/inf-xmpp-connection.h>
 #include <libinfinity/common/inf-keepalive.h>

--- a/code/core/textsessionview.cpp
+++ b/code/core/textsessionview.cpp
@@ -24,9 +24,7 @@
 #include <gtkmm/scrolledwindow.h>
 #include <gtkmm/textiter.h>
 
-#include <gtksourceview/gtksourcebuffer.h>
-#include <gtksourceview/gtksourcelanguage.h>
-#include <gtksourceview/gtksourcelanguagemanager.h>
+#include <gtksourceview/gtksource.h>
 
 #include <libinftextgtk/inf-text-gtk-buffer.h>
 

--- a/code/dialogs/preferences-dialog.cpp
+++ b/code/dialogs/preferences-dialog.cpp
@@ -22,8 +22,7 @@
 #include <gtkmm/scrolledwindow.h>
 #include <stdexcept>
 
-#include <gtksourceview/gtksourcestyleschememanager.h>
-#include <gtksourceview/gtksourcestylescheme.h>
+#include <gtksourceview/gtksource.h>
 
 #include <gnutls/x509.h>
 

--- a/code/operations/operation-export-html.cpp
+++ b/code/operations/operation-export-html.cpp
@@ -23,7 +23,7 @@
 #include "util/i18n.hpp"
 
 #include <gtkmm/textbuffer.h>
-#include <gtksourceview/gtksourcebuffer.h>
+#include <gtksourceview/gtksource.h>
 
 #include <libinftextgtk/inf-text-gtk-buffer.h>
 

--- a/code/operations/operation-open.cpp
+++ b/code/operations/operation-open.cpp
@@ -22,7 +22,7 @@
 #include <glibmm/main.h>
 
 #include <libinftextgtk/inf-text-gtk-buffer.h>
-#include <gtksourceview/gtksourcebuffer.h>
+#include <gtksourceview/gtksource.h>
 
 #include <cerrno>
 #include <cstring> // memmove. Is there some C++ replacement for this?


### PR DESCRIPTION
This removes a lot of compiler warnings like the following:
/usr/include/gtksourceview-3.0/gtksourceview/gtksourceview.h:29:6:
warning: #warning "Only <gtksourceview/gtksource.h> can be included
directly." [-Wcpp]