### PR TITLE
Add suggested desktop category

### DIFF
--- a/gobby-0.5.desktop.in
+++ b/gobby-0.5.desktop.in
@@ -7,6 +7,6 @@ Exec=gobby-0.5 %F
 Terminal=false
 Type=Application
 Icon=gobby-0.5
-Categories=TextEditor;Network;
+Categories=TextEditor;Utility;Network;
 StartupNotify=true
 MimeType=text/plain;x-scheme-handler/infinote;


### PR DESCRIPTION
https://standards.freedesktop.org/menu-spec/latest/apas02.html suggests
to add the Utility category if TextEditor is used.