### PR TITLE
Add desktop-id to Appstream metadata

### DIFF
--- a/gobby-0.5.metainfo.xml
+++ b/gobby-0.5.metainfo.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>de.0x539.gobby</id>
+  <launchable type="desktop-id">gobby-0.5.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <provides>
     <binary>gobby-0.5</binary>


### PR DESCRIPTION
It's needed for tools like appstream-generator to detect the associated desktop file.

See also: https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html#tag-dapp-launchable