### PR TITLE
Mark metainfo for translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ depcomp
 .dirstamp
 gobby-0.5
 gobby-0.5.desktop
+gobby-0.5.metainfo.xml
 gobby.iss
 *.gschema.valid
 *.gschema.xml

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,11 +67,12 @@ clean-local:
 	-rm -rf gobby-0.5.desktop
 
 @INTLTOOL_DESKTOP_RULE@
+@INTLTOOL_XML_RULE@
 
 EXTRA_DIST += README.md
 
 # For the manual
-EXTRA_DIST += gobby-0.5.desktop.in gobby-0.5.metainfo.xml
+EXTRA_DIST += gobby-0.5.desktop.in gobby-0.5.metainfo.xml.in
 DISTCLEANFILES += gnome-doc-utils.make
 DISTCHECK_CONFIGURE_FLAGS = --disable-scrollkeeper
 

--- a/gobby-0.5.metainfo.xml.in
+++ b/gobby-0.5.metainfo.xml.in
@@ -7,17 +7,17 @@
   <provides>
     <binary>gobby-0.5</binary>
   </provides>
-  <name>Gobby</name>
-  <summary>Collaborative text editor</summary>
+  <_name>Gobby</_name>
+  <_summary>Collaborative text editor</_summary>
 
   <description>
-    <p>
+    <_p>
       Gobby is a free collaborative editor supporting multiple documents in one session and a multi-user chat.
       It runs on Microsoft Windows, Mac OS X, Linux and other Unix-like platforms.
-    </p>
-    <p>
+    </_p>
+    <_p>
       It uses GTK+ as its windowing toolkit and thus integrates nicely into the GNOME desktop environment.
-    </p>
+    </_p>
   </description>
 
   <screenshots>
@@ -33,15 +33,15 @@
     <release version="0.6" date="2021-01-31">
       <description>
         <ul>
-          <li>Remove support for GTK+ 2.x; at least GTK+ 3.6 is required now.</li>
-          <li>Enable TCP keepalives, so that inactive connections will drop automatically after a short time.</li>
-          <li>Gobby is now registered as a handler for infinote:// URLs.</li>
-          <li>Remember hosts previously connected to and presents them in the list next time Gobby is started until expilictly removed.</li>
-          <li>Gobby can now show connection parameters, in particular TLS parameters used for the connection.</li>
-          <li>Gobby's configuration options are stored in GSettings instead of a custam config.xml file.</li>
-          <li>The option to not set a certificate in the initial welcome dialog is no longer available.</li>
-          <li>Gobby can now use the default system CAs on Windows.</li>
-          <li>Small bug fixes and code base modernization.</li>
+          <_li>Remove support for GTK+ 2.x; at least GTK+ 3.6 is required now.</_li>
+          <_li>Enable TCP keepalives, so that inactive connections will drop automatically after a short time.</_li>
+          <_li>Gobby is now registered as a handler for infinote:// URLs.</_li>
+          <_li>Remember hosts previously connected to and presents them in the list next time Gobby is started until expilictly removed.</_li>
+          <_li>Gobby can now show connection parameters, in particular TLS parameters used for the connection.</_li>
+          <_li>Gobby's configuration options are stored in GSettings instead of a custam config.xml file.</_li>
+          <_li>The option to not set a certificate in the initial welcome dialog is no longer available.</_li>
+          <_li>Gobby can now use the default system CAs on Windows.</_li>
+          <_li>Small bug fixes and code base modernization.</_li>
         </ul>
       </description>
     </release>

--- a/gobby-0.5.metainfo.xml.in
+++ b/gobby-0.5.metainfo.xml.in
@@ -9,6 +9,7 @@
   </provides>
   <_name>Gobby</_name>
   <_summary>Edit text files collaboratively</_summary>
+  <_developer_name>Armin Burgmeier</_developer_name>
 
   <description>
     <_p>

--- a/gobby-0.5.metainfo.xml.in
+++ b/gobby-0.5.metainfo.xml.in
@@ -8,7 +8,7 @@
     <binary>gobby-0.5</binary>
   </provides>
   <_name>Gobby</_name>
-  <_summary>Collaborative text editor</_summary>
+  <_summary>Edit text files collaboratively</_summary>
 
   <description>
     <_p>

--- a/gobby-0.5.metainfo.xml.in
+++ b/gobby-0.5.metainfo.xml.in
@@ -29,6 +29,8 @@
   <url type="homepage">https://gobby.github.io/</url>
   <url type="bugtracker">https://github.com/gobby/gobby/issues</url>
 
+  <translation type="gettext">gobby05</translation>
+
   <releases>
     <release version="0.6" date="2021-01-31">
       <description>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -58,3 +58,4 @@ code/util/i18n.hpp
 code/util/uri.cpp
 code/window.cpp
 gobby-0.5.desktop.in
+gobby-0.5.metainfo.xml.in

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gobby 0.4.94\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-31 11:22+0100\n"
+"POT-Creation-Date: 2022-04-29 13:01+0100\n"
 "PO-Revision-Date: 2012-12-04 18:12+0100\n"
 "Last-Translator: Jordi Mallach <jordi@sindominio.net>\n"
 "Language-Team: Catalan <ca@dodds.net>\n"
@@ -729,7 +729,7 @@ msgstr ""
 msgid "Document Browser"
 msgstr "Explorador de documents"
 
-#: ../gobby-0.5.desktop.in.h:1
+#: ../gobby-0.5.desktop.in.h:1 ../gobby-0.5.metainfo.xml.in.h:1
 msgid "Gobby"
 msgstr ""
 
@@ -743,9 +743,72 @@ msgstr "Editor col·laboratiu Gobby"
 msgid "Gobby Collaborative Editor (0.5)"
 msgstr "Editor col·laboratiu Gobby (0.5)"
 
-#: ../gobby-0.5.desktop.in.h:4
+#: ../gobby-0.5.desktop.in.h:4 ../gobby-0.5.metainfo.xml.in.h:2
 msgid "Edit text files collaboratively"
 msgstr "Editeu fitxers de text col·laborativament"
+
+#: ../gobby-0.5.metainfo.xml.in.h:3
+msgid "Armin Burgmeier"
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:4
+msgid ""
+"Gobby is a free collaborative editor supporting multiple documents in one "
+"session and a multi-user chat. It runs on Microsoft Windows, Mac OS X, Linux "
+"and other Unix-like platforms."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:5
+msgid ""
+"It uses GTK+ as its windowing toolkit and thus integrates nicely into the "
+"GNOME desktop environment."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:6
+msgid "Remove support for GTK+ 2.x; at least GTK+ 3.6 is required now."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:7
+msgid ""
+"Enable TCP keepalives, so that inactive connections will drop automatically "
+"after a short time."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:8
+msgid "Gobby is now registered as a handler for infinote:// URLs."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:9
+msgid ""
+"Remember hosts previously connected to and presents them in the list next "
+"time Gobby is started until expilictly removed."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:10
+msgid ""
+"Gobby can now show connection parameters, in particular TLS parameters used "
+"for the connection."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:11
+msgid ""
+"Gobby's configuration options are stored in GSettings instead of a custam "
+"config.xml file."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:12
+msgid ""
+"The option to not set a certificate in the initial welcome dialog is no "
+"longer available."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:13
+msgid "Gobby can now use the default system CAs on Windows."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:14
+msgid "Small bug fixes and code base modernization."
+msgstr ""
 
 #~ msgid "_Remove"
 #~ msgstr "_Elimina"

--- a/po/de.po
+++ b/po/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.4.93\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-31 11:22+0100\n"
+"POT-Creation-Date: 2022-04-29 13:01+0100\n"
 "PO-Revision-Date: 2010-02-07 09:40+0100\n"
 "Last-Translator: Michael Frey <michael.frey@gmx.ch>\n"
 "Language-Team: \n"
@@ -696,7 +696,7 @@ msgstr ""
 msgid "Document Browser"
 msgstr "Dokumentenliste"
 
-#: ../gobby-0.5.desktop.in.h:1
+#: ../gobby-0.5.desktop.in.h:1 ../gobby-0.5.metainfo.xml.in.h:1
 msgid "Gobby"
 msgstr "Gobby"
 
@@ -708,9 +708,72 @@ msgstr "Gemeinschaftlicher Editor"
 msgid "Gobby Collaborative Editor (0.5)"
 msgstr "Gobby Gemeinschaftlicher Editor (0.5)"
 
-#: ../gobby-0.5.desktop.in.h:4
+#: ../gobby-0.5.desktop.in.h:4 ../gobby-0.5.metainfo.xml.in.h:2
 msgid "Edit text files collaboratively"
 msgstr "Textdateien gemeinsam bearbeiten"
+
+#: ../gobby-0.5.metainfo.xml.in.h:3
+msgid "Armin Burgmeier"
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:4
+msgid ""
+"Gobby is a free collaborative editor supporting multiple documents in one "
+"session and a multi-user chat. It runs on Microsoft Windows, Mac OS X, Linux "
+"and other Unix-like platforms."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:5
+msgid ""
+"It uses GTK+ as its windowing toolkit and thus integrates nicely into the "
+"GNOME desktop environment."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:6
+msgid "Remove support for GTK+ 2.x; at least GTK+ 3.6 is required now."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:7
+msgid ""
+"Enable TCP keepalives, so that inactive connections will drop automatically "
+"after a short time."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:8
+msgid "Gobby is now registered as a handler for infinote:// URLs."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:9
+msgid ""
+"Remember hosts previously connected to and presents them in the list next "
+"time Gobby is started until expilictly removed."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:10
+msgid ""
+"Gobby can now show connection parameters, in particular TLS parameters used "
+"for the connection."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:11
+msgid ""
+"Gobby's configuration options are stored in GSettings instead of a custam "
+"config.xml file."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:12
+msgid ""
+"The option to not set a certificate in the initial welcome dialog is no "
+"longer available."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:13
+msgid "Gobby can now use the default system CAs on Windows."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:14
+msgid "Small bug fixes and code base modernization."
+msgstr ""
 
 #, fuzzy
 #~ msgid "_Disconnect from Server"

--- a/po/el_GR.po
+++ b/po/el_GR.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-31 11:22+0100\n"
+"POT-Creation-Date: 2022-04-29 13:01+0100\n"
 "PO-Revision-Date: 2010-06-20 17:27+0300\n"
 "Last-Translator: Yannis Kaskamanidis <kiolalis@gmail.com>\n"
 "Language-Team: Ελληνικά <kde-i18n-doc@kde.org>\n"
@@ -699,7 +699,7 @@ msgstr ""
 msgid "Document Browser"
 msgstr "Περιηγητής εγγράφου"
 
-#: ../gobby-0.5.desktop.in.h:1
+#: ../gobby-0.5.desktop.in.h:1 ../gobby-0.5.metainfo.xml.in.h:1
 msgid "Gobby"
 msgstr "Gobby"
 
@@ -711,9 +711,72 @@ msgstr "Συνεργατικός επεξεργαστής κειμένων"
 msgid "Gobby Collaborative Editor (0.5)"
 msgstr "Συνεργατικός επεξεργαστής κειμένων Gobby (0.5)"
 
-#: ../gobby-0.5.desktop.in.h:4
+#: ../gobby-0.5.desktop.in.h:4 ../gobby-0.5.metainfo.xml.in.h:2
 msgid "Edit text files collaboratively"
 msgstr "Συνεργατική επεξεργασία αρχείων κειμένου"
+
+#: ../gobby-0.5.metainfo.xml.in.h:3
+msgid "Armin Burgmeier"
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:4
+msgid ""
+"Gobby is a free collaborative editor supporting multiple documents in one "
+"session and a multi-user chat. It runs on Microsoft Windows, Mac OS X, Linux "
+"and other Unix-like platforms."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:5
+msgid ""
+"It uses GTK+ as its windowing toolkit and thus integrates nicely into the "
+"GNOME desktop environment."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:6
+msgid "Remove support for GTK+ 2.x; at least GTK+ 3.6 is required now."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:7
+msgid ""
+"Enable TCP keepalives, so that inactive connections will drop automatically "
+"after a short time."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:8
+msgid "Gobby is now registered as a handler for infinote:// URLs."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:9
+msgid ""
+"Remember hosts previously connected to and presents them in the list next "
+"time Gobby is started until expilictly removed."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:10
+msgid ""
+"Gobby can now show connection parameters, in particular TLS parameters used "
+"for the connection."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:11
+msgid ""
+"Gobby's configuration options are stored in GSettings instead of a custam "
+"config.xml file."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:12
+msgid ""
+"The option to not set a certificate in the initial welcome dialog is no "
+"longer available."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:13
+msgid "Gobby can now use the default system CAs on Windows."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:14
+msgid "Small bug fixes and code base modernization."
+msgstr ""
 
 #, fuzzy
 #~ msgid "_Disconnect from Server"

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gobby-0.4.93~dev\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-31 11:22+0100\n"
+"POT-Creation-Date: 2022-04-29 13:01+0100\n"
 "PO-Revision-Date: 2009-12-03 19:26-0000\n"
 "Last-Translator: Gabríel A. Pétursson <gabrielp@simnet.is>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Document Browser"
 msgstr "Document Browser"
 
-#: ../gobby-0.5.desktop.in.h:1
+#: ../gobby-0.5.desktop.in.h:1 ../gobby-0.5.metainfo.xml.in.h:1
 msgid "Gobby"
 msgstr "Gobby"
 
@@ -707,9 +707,72 @@ msgstr "Collaborative Editor"
 msgid "Gobby Collaborative Editor (0.5)"
 msgstr "Gobby Collaborative Editor (0.5)"
 
-#: ../gobby-0.5.desktop.in.h:4
+#: ../gobby-0.5.desktop.in.h:4 ../gobby-0.5.metainfo.xml.in.h:2
 msgid "Edit text files collaboratively"
 msgstr "Edit text files collaboratively"
+
+#: ../gobby-0.5.metainfo.xml.in.h:3
+msgid "Armin Burgmeier"
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:4
+msgid ""
+"Gobby is a free collaborative editor supporting multiple documents in one "
+"session and a multi-user chat. It runs on Microsoft Windows, Mac OS X, Linux "
+"and other Unix-like platforms."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:5
+msgid ""
+"It uses GTK+ as its windowing toolkit and thus integrates nicely into the "
+"GNOME desktop environment."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:6
+msgid "Remove support for GTK+ 2.x; at least GTK+ 3.6 is required now."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:7
+msgid ""
+"Enable TCP keepalives, so that inactive connections will drop automatically "
+"after a short time."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:8
+msgid "Gobby is now registered as a handler for infinote:// URLs."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:9
+msgid ""
+"Remember hosts previously connected to and presents them in the list next "
+"time Gobby is started until expilictly removed."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:10
+msgid ""
+"Gobby can now show connection parameters, in particular TLS parameters used "
+"for the connection."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:11
+msgid ""
+"Gobby's configuration options are stored in GSettings instead of a custam "
+"config.xml file."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:12
+msgid ""
+"The option to not set a certificate in the initial welcome dialog is no "
+"longer available."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:13
+msgid "Gobby can now use the default system CAs on Windows."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:14
+msgid "Small bug fixes and code base modernization."
+msgstr ""
 
 #, fuzzy
 #~ msgid "_Disconnect from Server"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gobby 0.5 fr\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-31 11:22+0100\n"
+"POT-Creation-Date: 2022-04-29 13:01+0100\n"
 "PO-Revision-Date: 2010-11-16 23:04+0100\n"
 "Last-Translator: Claude Paroz <claude@2xlibre.net>\n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -698,7 +698,7 @@ msgstr ""
 msgid "Document Browser"
 msgstr "Navigateur de documents"
 
-#: ../gobby-0.5.desktop.in.h:1
+#: ../gobby-0.5.desktop.in.h:1 ../gobby-0.5.metainfo.xml.in.h:1
 msgid "Gobby"
 msgstr "Gobby"
 
@@ -710,9 +710,72 @@ msgstr "Éditeur collaboratif"
 msgid "Gobby Collaborative Editor (0.5)"
 msgstr "Éditeur collaboratif Gobby (0.5)"
 
-#: ../gobby-0.5.desktop.in.h:4
+#: ../gobby-0.5.desktop.in.h:4 ../gobby-0.5.metainfo.xml.in.h:2
 msgid "Edit text files collaboratively"
 msgstr "Éditer des fichiers texte de manière collaborative"
+
+#: ../gobby-0.5.metainfo.xml.in.h:3
+msgid "Armin Burgmeier"
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:4
+msgid ""
+"Gobby is a free collaborative editor supporting multiple documents in one "
+"session and a multi-user chat. It runs on Microsoft Windows, Mac OS X, Linux "
+"and other Unix-like platforms."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:5
+msgid ""
+"It uses GTK+ as its windowing toolkit and thus integrates nicely into the "
+"GNOME desktop environment."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:6
+msgid "Remove support for GTK+ 2.x; at least GTK+ 3.6 is required now."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:7
+msgid ""
+"Enable TCP keepalives, so that inactive connections will drop automatically "
+"after a short time."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:8
+msgid "Gobby is now registered as a handler for infinote:// URLs."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:9
+msgid ""
+"Remember hosts previously connected to and presents them in the list next "
+"time Gobby is started until expilictly removed."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:10
+msgid ""
+"Gobby can now show connection parameters, in particular TLS parameters used "
+"for the connection."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:11
+msgid ""
+"Gobby's configuration options are stored in GSettings instead of a custam "
+"config.xml file."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:12
+msgid ""
+"The option to not set a certificate in the initial welcome dialog is no "
+"longer available."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:13
+msgid "Gobby can now use the default system CAs on Windows."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:14
+msgid "Small bug fixes and code base modernization."
+msgstr ""
 
 #, fuzzy
 #~ msgid "_Disconnect from Server"

--- a/po/gobby05.pot
+++ b/po/gobby05.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-31 11:22+0100\n"
+"POT-Creation-Date: 2022-04-29 13:01+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -655,7 +655,7 @@ msgstr ""
 msgid "Document Browser"
 msgstr ""
 
-#: ../gobby-0.5.desktop.in.h:1
+#: ../gobby-0.5.desktop.in.h:1 ../gobby-0.5.metainfo.xml.in.h:1
 msgid "Gobby"
 msgstr ""
 
@@ -667,6 +667,69 @@ msgstr ""
 msgid "Gobby Collaborative Editor (0.5)"
 msgstr ""
 
-#: ../gobby-0.5.desktop.in.h:4
+#: ../gobby-0.5.desktop.in.h:4 ../gobby-0.5.metainfo.xml.in.h:2
 msgid "Edit text files collaboratively"
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:3
+msgid "Armin Burgmeier"
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:4
+msgid ""
+"Gobby is a free collaborative editor supporting multiple documents in one "
+"session and a multi-user chat. It runs on Microsoft Windows, Mac OS X, Linux "
+"and other Unix-like platforms."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:5
+msgid ""
+"It uses GTK+ as its windowing toolkit and thus integrates nicely into the "
+"GNOME desktop environment."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:6
+msgid "Remove support for GTK+ 2.x; at least GTK+ 3.6 is required now."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:7
+msgid ""
+"Enable TCP keepalives, so that inactive connections will drop automatically "
+"after a short time."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:8
+msgid "Gobby is now registered as a handler for infinote:// URLs."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:9
+msgid ""
+"Remember hosts previously connected to and presents them in the list next "
+"time Gobby is started until expilictly removed."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:10
+msgid ""
+"Gobby can now show connection parameters, in particular TLS parameters used "
+"for the connection."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:11
+msgid ""
+"Gobby's configuration options are stored in GSettings instead of a custam "
+"config.xml file."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:12
+msgid ""
+"The option to not set a certificate in the initial welcome dialog is no "
+"longer available."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:13
+msgid "Gobby can now use the default system CAs on Windows."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:14
+msgid "Small bug fixes and code base modernization."
 msgstr ""

--- a/po/it_IT.po
+++ b/po/it_IT.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-31 11:22+0100\n"
+"POT-Creation-Date: 2022-04-29 13:01+0100\n"
 "PO-Revision-Date: 2016-10-27 23:27+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -711,7 +711,7 @@ msgstr "Questo Computer"
 msgid "Document Browser"
 msgstr "Browser Documenti"
 
-#: ../gobby-0.5.desktop.in.h:1
+#: ../gobby-0.5.desktop.in.h:1 ../gobby-0.5.metainfo.xml.in.h:1
 msgid "Gobby"
 msgstr "Gobby"
 
@@ -723,9 +723,72 @@ msgstr "Editor Collaborativo"
 msgid "Gobby Collaborative Editor (0.5)"
 msgstr "Gobby Editor Collaborativo (0.5)"
 
-#: ../gobby-0.5.desktop.in.h:4
+#: ../gobby-0.5.desktop.in.h:4 ../gobby-0.5.metainfo.xml.in.h:2
 msgid "Edit text files collaboratively"
 msgstr "Modifica file di testo in modo collaborativo"
+
+#: ../gobby-0.5.metainfo.xml.in.h:3
+msgid "Armin Burgmeier"
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:4
+msgid ""
+"Gobby is a free collaborative editor supporting multiple documents in one "
+"session and a multi-user chat. It runs on Microsoft Windows, Mac OS X, Linux "
+"and other Unix-like platforms."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:5
+msgid ""
+"It uses GTK+ as its windowing toolkit and thus integrates nicely into the "
+"GNOME desktop environment."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:6
+msgid "Remove support for GTK+ 2.x; at least GTK+ 3.6 is required now."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:7
+msgid ""
+"Enable TCP keepalives, so that inactive connections will drop automatically "
+"after a short time."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:8
+msgid "Gobby is now registered as a handler for infinote:// URLs."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:9
+msgid ""
+"Remember hosts previously connected to and presents them in the list next "
+"time Gobby is started until expilictly removed."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:10
+msgid ""
+"Gobby can now show connection parameters, in particular TLS parameters used "
+"for the connection."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:11
+msgid ""
+"Gobby's configuration options are stored in GSettings instead of a custam "
+"config.xml file."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:12
+msgid ""
+"The option to not set a certificate in the initial welcome dialog is no "
+"longer available."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:13
+msgid "Gobby can now use the default system CAs on Windows."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:14
+msgid "Small bug fixes and code base modernization."
+msgstr ""
 
 #~ msgid "_Remove"
 #~ msgstr "_Rimuovi"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gobby 0.4.94\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-31 11:22+0100\n"
+"POT-Creation-Date: 2022-04-29 13:01+0100\n"
 "PO-Revision-Date: 2010-11-19 01:09+0900\n"
 "Last-Translator: Takahiro Sunaga <sunagae@sunagae.net>\n"
 "Language-Team: Japanese\n"
@@ -687,7 +687,7 @@ msgstr ""
 msgid "Document Browser"
 msgstr "ドキュメントブラウザ"
 
-#: ../gobby-0.5.desktop.in.h:1
+#: ../gobby-0.5.desktop.in.h:1 ../gobby-0.5.metainfo.xml.in.h:1
 msgid "Gobby"
 msgstr "Gobby"
 
@@ -699,9 +699,72 @@ msgstr "共同作業テキストエディタ"
 msgid "Gobby Collaborative Editor (0.5)"
 msgstr "Gobby Collaborative Editor (0.5)"
 
-#: ../gobby-0.5.desktop.in.h:4
+#: ../gobby-0.5.desktop.in.h:4 ../gobby-0.5.metainfo.xml.in.h:2
 msgid "Edit text files collaboratively"
 msgstr "テキストを共同作業で編集する"
+
+#: ../gobby-0.5.metainfo.xml.in.h:3
+msgid "Armin Burgmeier"
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:4
+msgid ""
+"Gobby is a free collaborative editor supporting multiple documents in one "
+"session and a multi-user chat. It runs on Microsoft Windows, Mac OS X, Linux "
+"and other Unix-like platforms."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:5
+msgid ""
+"It uses GTK+ as its windowing toolkit and thus integrates nicely into the "
+"GNOME desktop environment."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:6
+msgid "Remove support for GTK+ 2.x; at least GTK+ 3.6 is required now."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:7
+msgid ""
+"Enable TCP keepalives, so that inactive connections will drop automatically "
+"after a short time."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:8
+msgid "Gobby is now registered as a handler for infinote:// URLs."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:9
+msgid ""
+"Remember hosts previously connected to and presents them in the list next "
+"time Gobby is started until expilictly removed."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:10
+msgid ""
+"Gobby can now show connection parameters, in particular TLS parameters used "
+"for the connection."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:11
+msgid ""
+"Gobby's configuration options are stored in GSettings instead of a custam "
+"config.xml file."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:12
+msgid ""
+"The option to not set a certificate in the initial welcome dialog is no "
+"longer available."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:13
+msgid "Gobby can now use the default system CAs on Windows."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:14
+msgid "Small bug fixes and code base modernization."
+msgstr ""
 
 #, fuzzy
 #~ msgid "_Disconnect from Server"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gobby 0.4.94\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-31 11:22+0100\n"
+"POT-Creation-Date: 2022-04-29 13:01+0100\n"
 "PO-Revision-Date: 2014-07-11 18:12+0100\n"
 "Last-Translator: Vitor Lobo <lobocode@gmail.com>\n"
 "Language-Team: Portuguese Brazilian <lobocode@fedoraproject.org>\n"
@@ -677,7 +677,7 @@ msgstr ""
 msgid "Document Browser"
 msgstr "Navegador do documento"
 
-#: ../gobby-0.5.desktop.in.h:1
+#: ../gobby-0.5.desktop.in.h:1 ../gobby-0.5.metainfo.xml.in.h:1
 msgid "Gobby"
 msgstr ""
 
@@ -689,9 +689,72 @@ msgstr "Editor colaborativo"
 msgid "Gobby Collaborative Editor (0.5)"
 msgstr ""
 
-#: ../gobby-0.5.desktop.in.h:4
+#: ../gobby-0.5.desktop.in.h:4 ../gobby-0.5.metainfo.xml.in.h:2
 msgid "Edit text files collaboratively"
 msgstr "Editar arquivos de texto de forma colaborativa"
+
+#: ../gobby-0.5.metainfo.xml.in.h:3
+msgid "Armin Burgmeier"
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:4
+msgid ""
+"Gobby is a free collaborative editor supporting multiple documents in one "
+"session and a multi-user chat. It runs on Microsoft Windows, Mac OS X, Linux "
+"and other Unix-like platforms."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:5
+msgid ""
+"It uses GTK+ as its windowing toolkit and thus integrates nicely into the "
+"GNOME desktop environment."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:6
+msgid "Remove support for GTK+ 2.x; at least GTK+ 3.6 is required now."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:7
+msgid ""
+"Enable TCP keepalives, so that inactive connections will drop automatically "
+"after a short time."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:8
+msgid "Gobby is now registered as a handler for infinote:// URLs."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:9
+msgid ""
+"Remember hosts previously connected to and presents them in the list next "
+"time Gobby is started until expilictly removed."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:10
+msgid ""
+"Gobby can now show connection parameters, in particular TLS parameters used "
+"for the connection."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:11
+msgid ""
+"Gobby's configuration options are stored in GSettings instead of a custam "
+"config.xml file."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:12
+msgid ""
+"The option to not set a certificate in the initial welcome dialog is no "
+"longer available."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:13
+msgid "Gobby can now use the default system CAs on Windows."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:14
+msgid "Small bug fixes and code base modernization."
+msgstr ""
 
 #, fuzzy
 #~ msgid "_Disconnect from Server"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gobby 0.4.94\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-01-31 11:22+0100\n"
+"POT-Creation-Date: 2022-04-29 13:01+0100\n"
 "PO-Revision-Date: 2010-06-26 17:11+0800\n"
 "Last-Translator: Wei-Lun Chao <chaoweilun@gmail.com>\n"
 "Language-Team: Chinese (traditional) <zh-l10n@linux.org.tw>\n"
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Document Browser"
 msgstr "文件瀏覽器"
 
-#: ../gobby-0.5.desktop.in.h:1
+#: ../gobby-0.5.desktop.in.h:1 ../gobby-0.5.metainfo.xml.in.h:1
 msgid "Gobby"
 msgstr "Gobby"
 
@@ -693,9 +693,72 @@ msgstr "共同編輯器"
 msgid "Gobby Collaborative Editor (0.5)"
 msgstr "Gobby 共同編輯器 (0.5)"
 
-#: ../gobby-0.5.desktop.in.h:4
+#: ../gobby-0.5.desktop.in.h:4 ../gobby-0.5.metainfo.xml.in.h:2
 msgid "Edit text files collaboratively"
 msgstr "共同編輯文字檔"
+
+#: ../gobby-0.5.metainfo.xml.in.h:3
+msgid "Armin Burgmeier"
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:4
+msgid ""
+"Gobby is a free collaborative editor supporting multiple documents in one "
+"session and a multi-user chat. It runs on Microsoft Windows, Mac OS X, Linux "
+"and other Unix-like platforms."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:5
+msgid ""
+"It uses GTK+ as its windowing toolkit and thus integrates nicely into the "
+"GNOME desktop environment."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:6
+msgid "Remove support for GTK+ 2.x; at least GTK+ 3.6 is required now."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:7
+msgid ""
+"Enable TCP keepalives, so that inactive connections will drop automatically "
+"after a short time."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:8
+msgid "Gobby is now registered as a handler for infinote:// URLs."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:9
+msgid ""
+"Remember hosts previously connected to and presents them in the list next "
+"time Gobby is started until expilictly removed."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:10
+msgid ""
+"Gobby can now show connection parameters, in particular TLS parameters used "
+"for the connection."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:11
+msgid ""
+"Gobby's configuration options are stored in GSettings instead of a custam "
+"config.xml file."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:12
+msgid ""
+"The option to not set a certificate in the initial welcome dialog is no "
+"longer available."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:13
+msgid "Gobby can now use the default system CAs on Windows."
+msgstr ""
+
+#: ../gobby-0.5.metainfo.xml.in.h:14
+msgid "Small bug fixes and code base modernization."
+msgstr ""
 
 #~ msgid "_Remove"
 #~ msgstr "移除(_R)"

--- a/update-potfiles
+++ b/update-potfiles
@@ -8,3 +8,4 @@ done
 grep --binary-files=without-match "_(" code -R | \
 	sed -e 's/:.*//' | uniq | sort > po/POTFILES.in
 echo gobby-0.5.desktop.in >> po/POTFILES.in
+echo gobby-0.5.metainfo.xml.in >> po.POTFILES.in


### PR DESCRIPTION
The information in the metainfo file is displayed to users in software centres such as GNOME Software, and so should be translated.

I also tweaked the summary, and so it ends up already having a number of translations.

Finally, I added metadata to allow the repo appstream generator to include data on which languages the app is translated into, and the developer name.

Fixes #194