### PR TITLE
Get settings default values from the settings schema

### DIFF
--- a/code/core/preferences.hpp
+++ b/code/core/preferences.hpp
@@ -24,6 +24,8 @@
 
 #include <gtkmm/toolbar.h>
 #include <giomm/settings.h>
+#include <giomm/settingsschema.h>
+#include <giomm/settingsschemakey.h>
 
 #include <gtksourceview/gtksource.h>
 
@@ -486,10 +488,11 @@ public:
 
 		bool is_default() const
 		{
+			Glib::VariantBase default_variant =
+				m_settings->property_settings_schema().get_value()->
+				get_key(m_key)->get_default_value();
 			Glib::VariantBase current_variant;
-			Glib::VariantBase default_variant;
 			m_settings->get_value(m_key, current_variant);
-			m_settings->get_default_value(m_key, default_variant);
 			return current_variant.equal(default_variant);
 		}
 


### PR DESCRIPTION
Hello,

As reported in #196, [`Gio::Settings::get_default_value()`](https://docs.gtk.org/gio/method.Settings.get_default_value.html) cannot be relied upon to determine whether a given setting has been set by the user, as it incorrectly considers as defaults the values from lower-level dconf databases when using a split dconf profile.

A more accurate check is to compare the actual value of the setting against its default value as specified in the settings schema (which can be retrieved using [`Gio::SettingsSchemaKey::get_default_value()`](https://docs.gtk.org/gio/method.SettingsSchemaKey.get_default_value.html)).

Fixes #196.

Thanks!\
SnipFoo