### PR TITLE
metainfo: Add OARS age-rating data

### DIFF
--- a/gobby-0.5.metainfo.xml.in
+++ b/gobby-0.5.metainfo.xml.in
@@ -32,6 +32,10 @@
 
   <translation type="gettext">gobby05</translation>
 
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-chat">intense</content_attribute>
+  </content_rating>
+
   <releases>
     <release version="0.6" date="2021-01-31">
       <description>


### PR DESCRIPTION
This data is used by software centre applications such as GNOME Software. The specification and generator are at https://hughsie.github.io/oars/. OARS data is mandatory on Flathub, so I included this patch [in the Flathub build of Gobby](https://github.com/flathub/de._0x539.gobby).

Walking through the generator, the only relevant attribute is 'social-chat':

> Online Text-only Messaging
> --------------------------
>
> Defined as any messaging system connected to the Internet.

The 'intense' value (the highest level) is defined as:

> Uncontrolled chat functionality between users.

Gobby is a network-connected text editor so its entire purpose is indeed uncontrolled text communication between users over a network or the internet.

At the time of writing, this rating causes libappstream to assign the app a minimum age of 13 years.