### PR TITLE
Implement secret storage using libsecret

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: "gobby: Install required packages"
         run: |
-          sudo apt-get install -y meson libsigc++-2.0-dev libxml++2.6-dev libglibmm-2.4-dev libgtkmm-3.0-dev libgtksourceview-4-dev libgsasl7-dev gettext yelp-tools desktop-file-utils appstream-util
+          sudo apt-get install -y meson libsigc++-2.0-dev libxml++2.6-dev libglibmm-2.4-dev libgtkmm-3.0-dev libgtksourceview-4-dev libgsasl7-dev libsecret-1-dev gettext yelp-tools desktop-file-utils appstream-util
 
       - name: "gobby: Run meson"
         run: |

--- a/NEWS
+++ b/NEWS
@@ -3,8 +3,11 @@ Gobby
 
 Version 0.7.0:
   * Use Meson for building instead of Autotools.
+  * Require C++17 for std::optional support.
   * Use GtkSourceView 4 instead of 3.
   * Bump GTK+ dependency to 3.22 for gtk_show_uri_on_window.
+  * Added support for libsecret as an optional dependency
+    (not available on Windows).
 
 Version 0.6.0:
   * Remove support for GTK+ 2.x; at least GTK+ 3.6 is required now.

--- a/code/commands/auth-commands.hpp
+++ b/code/commands/auth-commands.hpp
@@ -22,6 +22,7 @@
 #include "core/browser.hpp"
 #include "core/statusbar.hpp"
 #include "core/preferences.hpp"
+#include "util/secrets.hpp"
 
 #include <gtkmm/window.h>
 #include <sigc++/trackable.h>
@@ -101,7 +102,9 @@ protected:
 
 	struct RetryInfo {
 		unsigned int retries;
+		Glib::ustring username;
 		Glib::ustring last_password;
+		bool attempted_fetch_from_secret_store;
 		gulong handle;
 		PasswordDialog* password_dialog;
 	};

--- a/code/meson.build
+++ b/code/meson.build
@@ -4,6 +4,9 @@ conf.set_quoted('PACKAGE_STRING', meson.project_name() + ' ' + meson.project_ver
 conf.set_quoted('PACKAGE_VERSION', meson.project_version())
 conf.set_quoted('PRIVATE_ICONS_DIR', get_option('prefix') / get_option('datadir') / 'gobby-0.5' / 'icons')
 conf.set_quoted('PUBLIC_ICONS_DIR', get_option('prefix') / get_option('datadir') / 'icons')
+if libsecret_dep.found()
+  conf.set('HAVE_LIBSECRET', 1)
+endif
 
 configure_file(
   output : 'features.hpp',
@@ -107,6 +110,7 @@ executable('gobby-0.5',
       'util/file.cpp',
       'util/asyncoperation.cpp',
       'util/uri.cpp',
+      'util/secrets.cpp',
       'util/serialize.cpp',
       'util/i18n.cpp',
       'window.cpp',
@@ -151,7 +155,8 @@ executable('gobby-0.5',
       libinftext_dep,
       libinfgtk_dep,
       libinftextgtk_dep,
-      sigcpp_dep
+      sigcpp_dep,
+      libsecret_dep
       ],
     link_args : link_args,
     link_depends : link_depends,

--- a/code/util/secrets.cpp
+++ b/code/util/secrets.cpp
@@ -1,0 +1,120 @@
+/* Gobby - GTK-based collaborative text editor
+ * Copyright (C) 2024 Philipp Kern
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "features.hpp"
+#include "secrets.hpp"
+
+#ifdef HAVE_LIBSECRET
+# include <libsecret/secret.h>
+#endif
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+namespace Gobby {
+
+namespace {
+
+#ifdef HAVE_LIBSECRET
+const SecretSchema* get_schema()
+{
+	static const SecretSchema secret_schema = {
+		"de.0x539.gobby.Password", SECRET_SCHEMA_NONE,
+		{
+			{ "server", SECRET_SCHEMA_ATTRIBUTE_STRING },
+			{ "username", SECRET_SCHEMA_ATTRIBUTE_STRING },
+			{ "NULL", SECRET_SCHEMA_ATTRIBUTE_STRING },
+		}
+	};
+	return &secret_schema;
+}
+
+extern "C"
+{
+
+void on_password_stored(GObject* source, GAsyncResult* result, gpointer unused)
+{
+	GError* error = nullptr;
+	secret_password_store_finish(result, &error);
+	if (error != nullptr)
+	{
+		std::cerr << "Failed to store secret: " << error->message << std::endl;
+		g_error_free(error);
+	}
+}
+
+void on_password_lookup(GObject* source, GAsyncResult* result, gpointer user_data)
+{
+	std::unique_ptr<LookupCallback> password_callback{reinterpret_cast<LookupCallback*>(user_data)};
+	GError *error = nullptr;
+	gchar* password = secret_password_lookup_finish(result, &error);
+	if (error != nullptr)
+	{
+		std::cerr << "Failed to lookup secret: " << error->message << std::endl;
+		g_error_free(error);
+		(*password_callback)(std::nullopt);
+	}
+	else if (password == nullptr)
+	{
+		(*password_callback)(std::nullopt);
+	}
+	else
+	{
+		(*password_callback)(password);
+		secret_password_free(password);
+	}
+}
+
+} // extern "C"
+#endif
+
+} // namespace
+
+void store_secret(const std::string& server, const std::string& username, const std::string& password)
+{
+#ifdef HAVE_LIBSECRET
+	const std::string label = "Gobby password for \"" + username + "\" on \"" + server + "\"";
+	secret_password_store(get_schema(),
+			SECRET_COLLECTION_DEFAULT,
+			label.c_str(),
+			password.c_str(),
+			/*cancellable=*/NULL,
+			on_password_stored,
+			/*user_data=*/NULL,
+			"server", server.c_str(),
+			"username", username.c_str(),
+			NULL);
+#endif
+}
+
+void lookup_secret(const std::string& server, const std::string& username, LookupCallback password_callback)
+{
+#ifdef HAVE_LIBSECRET
+	auto callback = std::make_unique<LookupCallback>(password_callback);
+	secret_password_lookup(get_schema(),
+		/*cancellable=*/NULL,
+		on_password_lookup,
+		/*user_data=*/static_cast<void*>(callback.release()),
+		"server", server.c_str(),
+		"username", username.c_str(),
+		NULL);
+#else
+	password_callback(std::nullopt);
+#endif
+}
+
+} // namespace Gobby

--- a/code/util/secrets.hpp
+++ b/code/util/secrets.hpp
@@ -1,0 +1,40 @@
+/* Gobby - GTK-based collaborative text editor
+ * Copyright (C) 2024 Philipp Kern
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef _GOBBY_UTIL_SECRETS_HPP_
+#define _GOBBY_UTIL_SECRETS_HPP_
+
+#include <functional>
+#include <optional>
+#include <string>
+
+namespace Gobby
+{
+
+using LookupCallback = std::function<void(std::optional<std::string> password)>;
+
+// lookup_secret asynchronously attempts to lookup the password for the given
+// server and username combination in the keyring. Once the lookup attempt
+// completes, the callback is called.
+void lookup_secret(const std::string& server, const std::string& username, LookupCallback password_callback);
+
+// store_secret asynchronously attempts to store the password for the given server
+// and username in the keyring.
+void store_secret(const std::string& server, const std::string& username, const std::string& password);
+
+} // namespace Gobby
+
+#endif // _GOBBY_UTIL_SECRETS_HPP_

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('gobby', ['cpp', 'c'],
   version : '0.7.0',
   license : 'ISC',
-  default_options : ['cpp_std=c++11'])
+  default_options : ['cpp_std=c++17'])
 appname = 'gobby-0.5'
 
 ## TODO: WIN32 (+resources), make docs conditional
@@ -25,6 +25,7 @@ libgsasl_dep = dependency('libgsasl', version : '>= 0.2.21')
 gnutls_dep = dependency('gnutls', version : '>= 3.0.20')
 gtkmm_dep = dependency('gtkmm-3.0', version : '>= 3.22.0')
 gtksourceview_dep = dependency('gtksourceview-4')
+libsecret_dep = dependency('libsecret-1', required : false)
 
 libinfinity_dep = dependency('libinfinity-0.7')
 libinftext_dep = dependency('libinftext-0.7')


### PR DESCRIPTION
Persist password from successful connection attempts using libsecret into the local keyring (on !Windows, as libsecret requires a *nix). The passwords are keyed by target server and username.

Fixes #205